### PR TITLE
Update linking on Windows for upcoming version of Rtools.

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,6 +1,15 @@
 HTSLIB_DIR=htslib-1.18
 PKG_CPPFLAGS=-I. -I${HTSLIB_DIR} -D_FILE_OFFSET_BITS=64
-PKG_LIBS=${HTSLIB_DIR}/libhts.a -lm -lbz2 -llzma -lcurl -lbcrypt -lidn2 -lunistring -liconv -lssl -lcrypto -lcrypt32 -lwsock32 -lwldap32 -lssh2 -lgcrypt -lgpg-error -lws2_32 -lzstd -lregex -lz
+PKG_LIBS=${HTSLIB_DIR}/libhts.a
+
+ifeq (,$(shell pkg-config --version 2>/dev/null))
+  LIBPSL = $(or $(and $(wildcard $(R_TOOLS_SOFT)/lib/libpsl.a),-lpsl),)
+  LIBBROTLI = $(or $(and $(wildcard $(R_TOOLS_SOFT)/lib/libbrotlidec.a),-lbrotlidec -lbrotlicommon),)
+  PKG_LIBS += ${HTSLIB_DIR}/libhts.a -lm -lbz2 -llzma -lcurl $(LIBPSL) $(LIBBROTLI) -lbcrypt -lidn2 -lunistring -liconv -lssl -lcrypto -lcrypt32 -lwsock32 -lwldap32 -lssh2 -lgcrypt -lgpg-error -lws2_32 -lzstd -lregex -lz
+else
+  PKG_LIBS += -llzma -lbz2 -lregex $(shell pkg-config --libs libcurl)
+  PKG_CPPFLAGS += $(shell pkg-config --cflags libcurl)
+endif
 
 .PHONY: all clean HTSLIB
 


### PR DESCRIPTION
This updates the linking on Windows to work also with an upcoming version of Rtools. It also uses pkg-config (when available) to get curl library dependencies - this should reduce the need for updates following updates of Rtools.
